### PR TITLE
Fix annoying chroma-config typo

### DIFF
--- a/chroma-config.in
+++ b/chroma-config.in
@@ -33,7 +33,7 @@ yes)
 	;;
 *)
 ;;
-esace
+esac
 
 case $sse_dslash_enabled in
 yes)


### PR DESCRIPTION
There was an extra `e` at the end of one of the `esac`s in `chroma-config.in`.  This caused the installed version of `chroma-config` to fail, as syntactically invalid `bash`.  The stray `e` is removed.