### PR TITLE
Richardson CG

### DIFF
--- a/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_iter_refine_w.h
+++ b/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_iter_refine_w.h
@@ -288,7 +288,7 @@ namespace Chroma
           toDouble(aniso_coeffs[3]));
 
       switch (invParam.SolverType) {
-      case CG:
+      case CG: {
         QDPIO::cout << "Creating the CG Solver" << std::endl;
         inner_solver =
             new QPhiX::InvCG<REALT,
@@ -308,7 +308,9 @@ namespace Chroma
                                                          MdagM>(
             *M_outer, *inner_solver, toDouble(invParam.Delta), invParam.MaxIter);
 
-      case BICGSTAB: 
+        break;
+      }
+      case BICGSTAB: {
         QDPIO::cout << "Creating the BiCGStab Solver" << std::endl;
         inner_solver = new QPhiX::InvBiCGStab<InnerReal, InnerVec, InnerSoa, comp12>(
             *M_inner, invParam.MaxIter);
@@ -323,9 +325,12 @@ namespace Chroma
                                                          comp12>(
             *M_outer, *inner_solver, toDouble(invParam.Delta), invParam.MaxIter);
         break;
-      default:
+      }
+      default: {
         QDPIO::cerr << "UNKNOWN Solver Type" << std::endl;
         QDP_abort(1);
+        break;
+      }
       }
     }
 

--- a/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_iter_refine_w.h
+++ b/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_iter_refine_w.h
@@ -516,7 +516,7 @@ namespace Chroma
      * \return syssolver results
      */
     SystemSolverResults_t
-    biCgStabSolve(T &psi, const T &chi, AbsChronologicalPredictor4D<T> &predictor) const
+    biCGStabSolve(T &psi, const T &chi, AbsChronologicalPredictor4D<T> &predictor) const
     {
     	SystemSolverResults_t res;
     	Handle< LinearOperator<T> > MdagM( new MdagMLinOp<T>(A) );

--- a/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_iter_refine_w.h
+++ b/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_iter_refine_w.h
@@ -37,6 +37,7 @@
 #include "qphix_singleton.h"
 
 using namespace QDP;
+using namespace std;
 
 namespace Chroma
 {

--- a/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_w.h
+++ b/lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_w.h
@@ -38,7 +38,9 @@
 #include "qphix_singleton.h"
 #include "actions/ferm/invert/qphix/qphix_vec_traits.h"
 #include "qphix/blas_new_c.h"
+
 using namespace QDP;
+using namespace std;
 
 namespace Chroma
 {


### PR DESCRIPTION
# Exposing the QPhiX Richardson Solver with CG in Chroma

## Rationale

Chroma already has the QPhiX Richardson solver exposed, but only with BiCGStab
as a solver. For our Wilson clover simulaton, the BiCGStab seems to be really
unstable. Bartek has extended QPhiX such that one can use the CG in the
Richardson solver. We want to have this exposed in Chroma in order to use it
for our HMC simulation.

## Current Implementation

### HMC and Propagator Solver

With a `git grep QPHIX_CLOVER_ITER_REFINE_BICGSTAB_INVERTER` one can find where
the Richardson solver is defined within Chroma:

-   `lib/actions/ferm/invert/qphix/syssolver_linop_clover_qphix_iter_refine_w.cc`
-   `lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_iter_refine_w.cc`

In the `linop` file, there is a comment stating:

    Solve a MdagM*psi=chi linear system by CG2

Whereas in the `mdagm` file, there is a comment stating:

    Solve a MdagM*psi=chi linear system by CG2

The corresponding header files enlighten with the following comment:

    Solve a M*psi=chi linear system by BiCGStab

At this point, I am completely lost. I *guess* that one inverts M†M whereas
the other only inverts M. My bet is that `mdagm` solves M†M and `linop`
solves, well, just the linear operator M.

Indeed, there is one call to `mixed_solver` in the `linop` version and two
invocations in the `mdagm` variant:

    (*mixed_solver)(psi_s[1], chi_s[1], toDouble(invParam.RsdTarget),
                    res.n_count, rsd_final, site_flops, mv_apps, my_isign,
                    invParam.VerboseP);

Versus:

    (*mixed_solver)(tmp_qphix, chi_qphix, toDouble(invParam.RsdTarget),
                    n_count1, rsd_final, site_flops1, mv_apps1, -1,
                    invParam.VerboseP);
    // ...
    (*mixed_solver)(psi_qphix, tmp_qphix, toDouble(invParam.RsdTarget),
                    n_count2, rsd_final, site_flops2, mv_apps2, +1,
                    invParam.VerboseP);

So these two are indeed the solvers for the propagators (M) and the HMC (M†M).

Despite the comments in the code, both cases use the BiCGStab solver as the
inner solver. The outer solver always has been the BiCGStab solver, now it is
this only by default after Bartek's changes.

### “Regular” QPhiX Solver

For the regular QPhiX solver, there is an additional XML tag that can be used
to select the CG or BiCGStab solver. It would be nice if something similar
could be implemented for the Richardson solver such that the user can specify
whether CG or BiCGStab is to be used.

Analogously to the Richardson solver, the regular solver is defined in a HMC
and a propagator variant:

-   `lib/actions/ferm/invert/qphix/syssolver_linop_clover_qphix_w.cc`
-   `lib/actions/ferm/invert/qphix/syssolver_mdagm_clover_qphix_w.cc`

In the constructor of the parameter `struct`, it reads the solver type into an
`enum` variable:

    read(paramtop, "SolverType", SolverType);

And then later on there is a `switch` statement using dynamic polymorphism to
create the correct operator.

    switch (invParam.SolverType) {
        case CG: {
            QDPIO::cout << "Creating the CG Solver" << std::endl;
            cg_solver = new QPhiX::InvCG<REALT, VecTraits<REALT>::Vec,
                                         VecTraits<REALT>::Soa,
                                         VecTraits<REALT>::compress12>(
                (*M), invParam.MaxIter);
        } break;

        case BICGSTAB: {
            QDPIO::cout << "Creating the BiCGStab Solver" << std::endl;
            bicgstab_solver =
                new QPhiX::InvBiCGStab<REALT, VecTraits<REALT>::Vec,
                                       VecTraits<REALT>::Soa,
                                       VecTraits<REALT>::compress12>(
                    (*M), invParam.MaxIter);
        } break;
        default:
            QDPIO::cerr << "UNKNOWN Solver Type" << std::endl;
            QDP_abort(1);
    }

For the inversion of M, the actual inversions happen these two functions:

    SystemSolverResults_t cgnrSolve(T &psi, const T &chi) const;
    SystemSolverResults_t biCGStabSolve(T &psi, const T &chi) const;

This uses the “conjugate gradient normal relation” to invert M using CG whereas
for BiCGStab this is just a simple application. For the M†M case in the other
file, there are these methods:

    SystemSolverResults_t biCGStabSolve(
        T &psi, const T &chi, AbsChronologicalPredictor4D<T> &predictor) const;
    SystemSolverResults_t cgSolve(
        T &psi, const T &chi, AbsChronologicalPredictor4D<T> &predictor) const;

There is a `switch` statement on the `operator()` which chooses the right
function to call based on the runtime parameter.

    switch (invParam.SolverType) {
        case CG: {
            res = cgSolve(psi, chi, predictor);
        } break;
        case BICGSTAB: {
            res = biCGStabSolve(psi, chi, predictor);
        } break;
        default:
            QDPIO::cout << "Unknown Solver " << std::endl;
            break;
    }

## Planning

The regular QPhiX solvers (solvers meaning inverter for M and M†M) have a
`switch` to allow for both CG and BiCGStab. There is no dynamic polymorphism
involved because CG might need the normal relation in the M case and BiCGStab
needs two applications in the M†M case. Therefore this should be applicable to
the Richardson solver as well.

For now we only need the Richardson solver in the HMC as we do our propagators
with the sLapH method using the peram_gen code based on tmLQCD and QUDA.
Therefore I will start with the M†M implementation and do the M implementation
later on.

## Implementation

The new feature needs to be developed against Bartek's QPhiX branch. This has
to be compiled and installed locally, then Chroma has to build against this.
This worked directly, which is a nice surprise.

The regular and Richardson solvers share the `SysSolverQPhiXCloverParams`
`struct` which means that also has the field `SolverType`. Therefore the XML
parsing does not need to be changed, the option just needs to be honored. In
the `syssolver_mdagm_clover_qphix_iter_refine_w.h`, I add the same `switch`
statement as there is already in `syssolver_mdagm_clover_qphix_w.h` in the
following places:

-   The constructor now constructs either a CG or a BiCGStab solver to be used
    as the outer solver.
-   The `operator()` which takes the chronological predictor has the `switch`.

The regular QPhiX solver has member functions `cgSolve` and `biCGStabSolve`.
Similar functions are going to be implemented in the Richardson case as well.
There the `operator()` is renamed into `biCGStabSolve`, the `cgSolve` is added
analogously to the regular CG case. This will be easier to implement because I
just need to call CG once and I have solved M†M.

## Testing

### Short HMC on my Laptop

I have compiled Chroma using Bartek's QPhiX branch on my AVX laptop and tested
the HMC with Nf = 2 on a 8³×8 lattice from a random starting configuration. I
have let it two trajectories with just a single time step on the outermost time
scale. I have used two MPI ranks with four threads each (effectively
oversubscribing my laptop)

Comparing CG (`-`) with Richardson-CG (`+`), one can see that there are
changes, but not very large. I would conclude that the Richardson-CG did not
break anything.

    -              <PE_old>-16985.682690378</PE_old>
    +              <PE_old>-16985.6827849023</PE_old>

    -              <KE_new>33974.0571754877</KE_new>
    +              <KE_new>33974.0638706824</KE_new>

    -              <PE_new>-50450.2118875695</PE_new>
    +              <PE_new>-50450.2159562068</PE_new>

    -            <deltaKE>34020.4653290306</deltaKE>
    +            <deltaKE>34020.4720242253</deltaKE>

    -            <deltaPE>-33464.5291971914</deltaPE>
    +            <deltaPE>-33464.5331713045</deltaPE>

    -            <deltaH>555.93613183916</deltaH>
    +            <deltaH>555.938852920808</deltaH>

    -            <AccProb>3.63082779652542e-242</AccProb>
    +            <AccProb>3.62096144730027e-242</AccProb>

![diff](https://user-images.githubusercontent.com/976924/29612890-cd9a2d78-8803-11e7-8e07-aa48f979b6eb.png)

You can have a look at the input file [hmc-in.xml.txt](https://github.com/JeffersonLab/chroma/files/1245169/hmc-in.xml.txt), the output from plain CG
[dat-cg.xml.txt](https://github.com/JeffersonLab/chroma/files/1245167/dat-cg.xml.txt), and the output from Richardson-CG [dat-richardson-cg.xml.txt](https://github.com/JeffersonLab/chroma/files/1245168/dat-richardson-cg.xml.txt).



The time to solution overall seems to be the same, this can probably not be
seen on my laptop with a non-thermalized random configuration.