### PR TITLE
Solver exception

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -40,6 +40,7 @@ nobase_include_HEADERS = \
 	actions/ferm/fermstates/extfield.h \
 	actions/ferm/fermstates/stout_fermstate_params.h \
 	actions/ferm/fermstates/hex_fermstate_params.h \
+	actions/ferm/invert/mg_solver_exception.h \
 	actions/ferm/invert/invcg1.h actions/ferm/invert/invcg2.h \
 	actions/ferm/invert/inv_eigcg2.h \
 	actions/ferm/invert/inv_eigcg2_array.h \

--- a/lib/actions/ferm/invert/mg_proto/syssolver_linop_clover_mg_proto_qphix.cc
+++ b/lib/actions/ferm/invert/mg_proto/syssolver_linop_clover_mg_proto_qphix.cc
@@ -17,6 +17,8 @@
 #include "lattice/qphix/invfgmres_qphix.h"
 #include "lattice/qphix/qphix_qdp_utils.h"
 #include "lattice/qphix/qphix_clover_linear_operator.h"
+#include "actions/ferm/invert/mg_solver_exception.h"
+
 #include <memory>
 using namespace QDP;
 
@@ -138,6 +140,15 @@ namespace Chroma
 		  Double n2 = norm2(tmp);
 		  Double n2rel = n2 / norm2(chi);
 		  QDPIO::cout << "MG_PROTO_CLOVER_INVERTER: iters = "<< res.n_count << " rel resid = " << sqrt(n2rel) << std::endl;
+		  if( toBool( sqrt(n2rel) > invParam.OuterSolverRsdTarget ) ) {
+		    MGSolverException convergence_fail(invParam.CloverParams.Mass, 
+						       subspaceId,
+						       res.n_count,
+						       Real(sqrt(n2rel)),
+						       invParam.OuterSolverRsdTarget);
+		    throw convergence_fail;
+
+		  }
 	  }
 	  swatch.stop();
 	  QDPIO::cout << "MG_PROTO_CLOVER_INVERTER_TIME: call_time = "<< swatch2.getTimeInSeconds() << " sec.  total_time=" << swatch.getTimeInSeconds() << " sec." << std::endl;

--- a/lib/actions/ferm/invert/mg_solver_exception.h
+++ b/lib/actions/ferm/invert/mg_solver_exception.h
@@ -1,0 +1,45 @@
+#include "chromabase.h"
+#include <exception>
+#include <string>
+#include <sstream>
+namespace Chroma  {
+
+  class MGSolverException : public std::exception 
+  {
+  public: 
+    MGSolverException(const Real& Mass, const std::string& SubspaceId, int Iters, const Real& Rsd, const Real& RsdTarget) : 
+      _Mass(Mass), _SubspaceId(SubspaceId), _Iters(Iters), _Rsd(Rsd), _RsdTarget(RsdTarget) {}
+
+    
+    virtual const char* what() const throw()
+    {
+      std::ostringstream message;
+      message << "MultiGrid Exception. SubspaceId=" << _SubspaceId
+	      << " Mass=" << _Mass
+	      << " Iters=" << _Iters
+	      << " RsdTarget=" << _RsdTarget 
+	      << " Rsd=" << _Rsd << std::endl;
+
+      std::string message_string = message.str();
+
+      return message_string.c_str();
+
+    }
+
+    const Real&  getMass() const { return _Mass; }
+    const std::string&  getSubspaceID() const { return _SubspaceId; }
+    const int& getIters() const { return _Iters; }
+    const Real& getRsd() const { return _Rsd; }
+    const Real& getRsdTarget() const { return _RsdTarget; }
+
+  private:
+    Real _Mass; // quark mass
+    std::string _SubspaceId; // the subspace
+    int _Iters; // Number of iterations taken
+    Real _Rsd;  // Actual Residuum 
+    Real _RsdTarget; // Target Residuum
+
+  };
+
+
+}

--- a/lib/actions/ferm/invert/mg_solver_exception.h
+++ b/lib/actions/ferm/invert/mg_solver_exception.h
@@ -8,24 +8,28 @@ namespace Chroma  {
   {
   public: 
     MGSolverException(const Real& Mass, const std::string& SubspaceId, int Iters, const Real& Rsd, const Real& RsdTarget) : 
-      _Mass(Mass), _SubspaceId(SubspaceId), _Iters(Iters), _Rsd(Rsd), _RsdTarget(RsdTarget) {}
-
-    
-    virtual const char* what() const throw()
-    {
+    _Mass(Mass), _SubspaceId(SubspaceId), _Iters(Iters), _Rsd(Rsd), _RsdTarget(RsdTarget) {
       std::ostringstream message;
       message << "MultiGrid Exception. SubspaceId=" << _SubspaceId
 	      << " Mass=" << _Mass
 	      << " Iters=" << _Iters
 	      << " RsdTarget=" << _RsdTarget 
-	      << " Rsd=" << _Rsd << std::endl;
+	      << " Rsd=" << _Rsd ;
 
-      std::string message_string = message.str();
+      _MsgString = message.str();
 
-      return message_string.c_str();
 
     }
 
+    
+    virtual const char* what() const throw()
+    {
+
+      return _MsgString.c_str();
+
+    }
+
+    const std::string& whatStr() const { return _MsgString; }
     const Real&  getMass() const { return _Mass; }
     const std::string&  getSubspaceID() const { return _SubspaceId; }
     const int& getIters() const { return _Iters; }
@@ -38,7 +42,7 @@ namespace Chroma  {
     int _Iters; // Number of iterations taken
     Real _Rsd;  // Actual Residuum 
     Real _RsdTarget; // Target Residuum
-
+    std::string _MsgString; // The error string
   };
 
 

--- a/lib/actions/ferm/invert/quda_solvers/syssolver_mdagm_clover_quda_multigrid_w.h
+++ b/lib/actions/ferm/invert/quda_solvers/syssolver_mdagm_clover_quda_multigrid_w.h
@@ -28,6 +28,7 @@ using namespace QDP;
 #include "lmdagm.h"
 #include "util/gauge/reunit.h"
 #include "actions/ferm/invert/quda_solvers/quda_mg_utils.h"
+#include "actions/ferm/invert/mg_solver_exception.h"
 
 //#include <util_quda.h>
 #ifdef BUILD_QUDA
@@ -784,7 +785,13 @@ public:
 	res_tmp.resid = sqrt(norm2(r, A->subset()));
 	if ( toBool( res_tmp.resid/norm2chi > invParam.RsdToleranceFactor * invParam.RsdTarget ) ) {
 	  QDPIO::cout << solver_string << "Re Solve for Y Failed. Rsd = " << res_tmp.resid/norm2chi << " RsdTarget = " << invParam.RsdTarget << std::endl;
-	  QDP_abort(1);
+	  QDPIO::cout << solver_string << "Throwing Exception! This will REJECT your trajectory" << std::endl;
+	  MGSolverException convergence_fail(invParam.CloverParams.Mass,
+                                             invParam.SaveSubspaceID,
+        	                             res_tmp.n_count,
+                                             Real(res_tmp.resid/norm2chi),
+                                             invParam.RsdTarget*invParam.RsdToleranceFactor);
+          throw convergence_fail;
 	}
       } // Check solution
 
@@ -903,6 +910,14 @@ public:
 	res_tmp.resid = sqrt(norm2(r, A->subset()));
 	if ( toBool( res_tmp.resid/norm2chi > invParam.RsdToleranceFactor * invParam.RsdTarget ) ) {
 	  QDPIO::cout << solver_string << "Re Solve for X Failed. Rsd = " << res_tmp.resid/norm2chi << " RsdTarget = " << invParam.RsdTarget << std::endl;
+	  QDPIO::cout << solver_string << "Throwing Exception! This will REJECT your trajectory" << std::endl;
+          MGSolverException convergence_fail(invParam.CloverParams.Mass,
+                                             invParam.SaveSubspaceID,
+                                             res_tmp.n_count,
+                                             Real(res_tmp.resid/norm2chi),
+                                             invParam.RsdTarget*invParam.RsdToleranceFactor);
+          throw convergence_fail;
+
 	  QDP_abort(1);
 	}
       }
@@ -1104,7 +1119,13 @@ public:
 	if ( toBool( res_tmp.resid/norm2chi > invParam.RsdToleranceFactor * invParam.RsdTarget ) ) {
 	  // If we fail on the resolve then barf
 	  QDPIO::cout << solver_string << "Re Solve for Y Failed. Rsd = " << res_tmp.resid/norm2chi << " RsdTarget = " << invParam.RsdTarget << std::endl;
-	  QDP_abort(1);
+	  QDPIO::cout << solver_string << "Throwing Exception! This will REJECT your trajectory" << std::endl;
+          MGSolverException convergence_fail(invParam.CloverParams.Mass,
+                                             invParam.SaveSubspaceID,
+                                             res_tmp.n_count,
+                                             Real(res_tmp.resid/norm2chi),
+                                             invParam.RsdTarget*invParam.RsdToleranceFactor);
+          throw convergence_fail;
 	}
       } 
 
@@ -1238,7 +1259,13 @@ public:
 	res_tmp.resid = sqrt(norm2(r, A->subset()));
 	if ( toBool( res_tmp.resid/norm2chi > invParam.RsdToleranceFactor * invParam.RsdTarget ) ) {
 	  QDPIO::cout << solver_string << "Re Solve for X Failed. Rsd = " << res_tmp.resid/norm2chi << " RsdTarget = " << invParam.RsdTarget << std::endl;
-	  QDP_abort(1);
+	  QDPIO::cout << solver_string << "Throwing Exception! This will REJECT your trajectory" << std::endl;
+          MGSolverException convergence_fail(invParam.CloverParams.Mass,
+                                             invParam.SaveSubspaceID,
+                                             res_tmp.n_count,
+                                             Real(res_tmp.resid/norm2chi),
+                                             invParam.RsdTarget*invParam.RsdToleranceFactor);
+          throw convergence_fail;
 	}
       }
       // At this point the solution is good

--- a/lib/update/molecdyn/hmc/abs_hmc.h
+++ b/lib/update/molecdyn/hmc/abs_hmc.h
@@ -13,7 +13,7 @@
 #include "update/molecdyn/hamiltonian//abs_hamiltonian.h"
 #include "update/molecdyn/integrator/abs_integrator.h"
 #include "update/molecdyn/hmc/global_metropolis_accrej.h"
-
+#include "actions/ferm/invert/mg_solver_exception.h"
 
 
 namespace Chroma 
@@ -37,6 +37,7 @@ namespace Chroma
       START_CODE();
       StopWatch swatch;
 
+
       AbsMDIntegrator<P,Q>& MD = getMDIntegrator();
       AbsHamiltonian<P,Q>& H_MC = getMCHamiltonian();
 
@@ -47,9 +48,10 @@ namespace Chroma
       push(xml_out, "HMCTrajectory");
       push(xml_log, "HMCTrajectory");
 
+
       write(xml_out, "WarmUpP", WarmUpP);
       write(xml_log, "WarmUpP", WarmUpP);
-
+      
       // HMC Algorithm.
       // 1) Refresh momenta
       //
@@ -58,162 +60,225 @@ namespace Chroma
       swatch.stop();
       QDPIO::cout << "HMC_TIME: Momentum Refresh Time: " << swatch.getTimeInSeconds() << " \n";
 
-      // Refresh Pseudofermions
-      swatch.reset(); swatch.start();
-      H_MC.refreshInternalFields(s);
-      swatch.stop();
-      QDPIO::cout << "HMC_TIME: Pseudofermion Refres Time: " << swatch.getTimeInSeconds() << " \n";
+      bool acceptTraj = false; // Default value. Acceptance check can change this
+      Double KE_old, PE_old;
 
+
+      // Try catch block in case MG Solver fails in any pseudofermion refresh.
+      // That should cause an abort.
+      try { 
+	// Refresh Pseudofermions
+	swatch.reset(); swatch.start();
+	H_MC.refreshInternalFields(s);
+	swatch.stop();
+	QDPIO::cout << "HMC_TIME: Pseudofermion Refres Time: " << swatch.getTimeInSeconds() << " \n";
+      }
+      catch ( MGSolverException e ) {
+	QDPIO::cout << "ERROR: Caught MG Solver exception in pseudofermion refresh" << std::endl;
+	QDPIO::cout << "ERROR: Exception Was: " << e.whatStr() << std::endl;
+	QDPIO::cout << "Aborting";
+	QDP_abort(1);
+      }
 
       // SaveState -- Perhaps this could be done better?
       Handle< AbsFieldState<P,Q> >  s_old(s.clone());
+
       
-      // Measure energy of the old state
-      Double KE_old, PE_old;
+      // Try Catch block in case MG Solver fails in Energy Calculation
+      // That should also be an abort
+      try {
+	// Measure energy of the old state
 
-      push(xml_out, "H_old");
-      push(xml_log, "H_old");
-      swatch.reset(); swatch.start();
-      H_MC.mesE(*s_old, KE_old, PE_old);
-      swatch.stop();
-      QDPIO::cout << "HMC_TIME: Start Energy Time: " << swatch.getTimeInSeconds() << " \n";
-
-      write(xml_out, "KE_old", KE_old);
-      write(xml_log, "KE_old", KE_old);
-
-      write(xml_out, "PE_old", PE_old);
-      write(xml_log, "PE_old", PE_old);
-
-      pop(xml_log); // pop H_old
-      pop(xml_out); // pop H_old
-      
-      swatch.start();
-      
-      // Copy in fields from the Hamiltonian as needed using the
-      // CopyList
-      MD.copyFields();
-
-      // Integrate MD trajectory
-      MD(s, MD.getTrajLength());
-      swatch.stop();
-      QDPIO::cout << "HMC_TIME: Traj MD Time: " << swatch.getTimeInSeconds() << " \n";
-           
-
-      // If this is a reverse trajectory
-      if( CheckRevP ) { 
+	push(xml_out, "H_old");
+	push(xml_log, "H_old");
 	swatch.reset(); swatch.start();
-
-	QDPIO::cout << "Reversing trajectory for reversability test" <<std::endl;
-
-	// Copy state
-	Handle< AbsFieldState<P,Q> >  s_rev(s.clone());
-	
-	// Flip Momenta
-	flipMomenta(*s_rev);
-	
-	// Go back
-	MD(*s_rev, MD.getTrajLength());
-
-	// Flip Momenta back (to original)
-	flipMomenta(*s_rev);
-
-
-	Double KE_rev;
-	Double PE_rev;
-       
-	H_MC.mesE(*s_rev, KE_rev, PE_rev);
-
-	Double DeltaDeltaKE = KE_rev - KE_old;
-	Double DeltaDeltaPE = PE_rev - PE_old;
-	Double DeltaDeltaH = DeltaDeltaKE + DeltaDeltaPE;
-
-	
-	Double dq;
-	Double dp;
-	reverseCheckMetrics(dq,dp, *s_rev, *s_old);
-
-	push(xml_log, "ReversibilityMetrics");
-	write(xml_log, "DeltaDeltaH", fabs(DeltaDeltaH));
-	write(xml_log, "DeltaDeltaKE", fabs(DeltaDeltaKE));
-	write(xml_log, "DeltaDeltaPE", fabs(DeltaDeltaPE));
-	write(xml_log, "DeltaQPerSite", dq);
-	write(xml_log, "DeltaPPerSite", dp);
-	pop(xml_log);
-
-	QDPIO::cout << "Reversibility: DeltaDeltaH = " << fabs(DeltaDeltaH) <<std::endl;
-	QDPIO::cout << "Reversibility: DeltaQ      = " << dq << std::endl;
-	QDPIO::cout << "Reversibility: DeltaP      = " << dp << std::endl;
+	H_MC.mesE(*s_old, KE_old, PE_old);
 	swatch.stop();
-	QDPIO::cout << "HMC_TIME: Reverse Check Time: " << swatch.getTimeInSeconds() << " \n";
-
+	QDPIO::cout << "HMC_TIME: Start Energy Time: " << swatch.getTimeInSeconds() << " \n";
 	
-	// s_rev goes away... We continue as if nothing happened
+	write(xml_out, "KE_old", KE_old);
+	write(xml_log, "KE_old", KE_old);
 	
+	write(xml_out, "PE_old", PE_old);
+	write(xml_log, "PE_old", PE_old);
+	
+	pop(xml_log); // pop H_old
+	pop(xml_out); // pop H_old
       }
-      swatch.reset(); 
-      swatch.start();
-      //  Measure the energy of the new state
-      Double KE, PE;
+      catch( MGSolverException e ) { 
+	QDPIO::cout << "ERROR: Caught MG Solver exception in Start Energy Calculation" << std::endl;
+	QDPIO::cout << "ERROR: Exception Was: " << e.whatStr() << std::endl;
+	QDPIO::cout << "Aborting";
+	QDP_abort(1);
+      }
+      
+      // Try-Catch Case for MD
+      // If solver fails in MD, we reject by setting acceptTraj = false
+      // If traj is sccessful (no exception is thrown) acceptTraj = true for WarmUp traj and 
+      //    is decided by Accept/Reject step otherwise
 
+      try {	
+	swatch.start();
+      
+	// Copy in fields from the Hamiltonian as needed using the
+	// CopyList
+	MD.copyFields();
 
-      push(xml_out, "H_new");
-      push(xml_log, "H_new");
-      H_MC.mesE(s, KE, PE);
-      write(xml_out, "KE_new", KE);
-      write(xml_log, "KE_new", KE);
-      write(xml_out, "PE_new", PE);
-      write(xml_log, "PE_new", PE);
-      pop(xml_log);
-      pop(xml_out);
-      swatch.stop();
-      QDPIO::cout << "HMC_TIME: Finish Energy Time: " << swatch.getTimeInSeconds() << " \n";
+	// Integrate MD trajectory
+	MD(s, MD.getTrajLength());
+	swatch.stop();
+	QDPIO::cout << "HMC_TIME: Traj MD Time: " << swatch.getTimeInSeconds() << " \n";
+           
+	// Measure the energy of the new state - before reverse check
+	// This is because if an MG preconditioner is used, the reverse
+	// traj may change it to where it is a poor preconditioner for the 
+	// Final energy calculation
+	swatch.reset(); 
+	swatch.start();
+	Double KE, PE;
+	push(xml_out, "H_new");
+	push(xml_log, "H_new");
+	H_MC.mesE(s, KE, PE);
+	write(xml_out, "KE_new", KE);
+	write(xml_log, "KE_new", KE);
+	write(xml_out, "PE_new", PE);
+	write(xml_log, "PE_new", PE);
+	pop(xml_log);
+	pop(xml_out);
+	swatch.stop();
+	QDPIO::cout << "HMC_TIME: Finish Energy Time: " << swatch.getTimeInSeconds() << " \n";
+	// Work out energy differences
+	Double DeltaKE = KE - KE_old;
+	Double DeltaPE = PE - PE_old;
+	Double DeltaH  = DeltaKE + DeltaPE;
+	Double AccProb = where(DeltaH < 0.0, Double(1), exp(-DeltaH));
+	write(xml_out, "deltaKE", DeltaKE);
+	write(xml_log, "deltaKE", DeltaKE);
+	
+	write(xml_out, "deltaPE", DeltaPE);
+	write(xml_log, "deltaPE", DeltaPE);
+	
+	write(xml_out, "deltaH", DeltaH);
+	write(xml_log, "deltaH", DeltaH);
+	
+	write(xml_out, "AccProb", AccProb);
+	write(xml_log, "AccProb", AccProb);
+	
+	QDPIO::cout << "Delta H = " << DeltaH << std::endl;
+	QDPIO::cout << "AccProb = " << AccProb << std::endl;
 
-      // Work out energy differences
-      Double DeltaKE = KE - KE_old;
-      Double DeltaPE = PE - PE_old;
-      Double DeltaH  = DeltaKE + DeltaPE;
-      Double AccProb = where(DeltaH < 0.0, Double(1), exp(-DeltaH));
-      write(xml_out, "deltaKE", DeltaKE);
-      write(xml_log, "deltaKE", DeltaKE);
-
-      write(xml_out, "deltaPE", DeltaPE);
-      write(xml_log, "deltaPE", DeltaPE);
-
-      write(xml_out, "deltaH", DeltaH);
-      write(xml_log, "deltaH", DeltaH);
-
-      write(xml_out, "AccProb", AccProb);
-      write(xml_log, "AccProb", AccProb);
-
-      QDPIO::cout << "Delta H = " << DeltaH << std::endl;
-      QDPIO::cout << "AccProb = " << AccProb << std::endl;
-
-      // If we intend to do an accept reject step
-      // (ie we are not warming up)
-      if( ! WarmUpP ) 
-      { 
-	// Measure Acceptance
-	bool acceptTestResult = acceptReject(DeltaH);
-	write(xml_out, "AcceptP", acceptTestResult);
-	write(xml_log, "AcceptP", acceptTestResult);
-
-	QDPIO::cout << "AcceptP = " << acceptTestResult << std::endl;
-
-	// If rejected restore fields
-	// If accepted no need to do anything
-	if ( ! acceptTestResult ) 
-	{ 
-	  s.getQ() = s_old->getQ();
-	  
-	  // I am going to refresh these so maybe these copies 
-	  //  for the momenta and the pseudofermions
-	  // are not really needed...
-	  //
-	  // restore momenta
-	  s.getP() = s_old->getP();
+	// If we intend to do an accept reject step
+	// (ie we are not warming up)
+	if( !WarmUpP ) {
+	 
+	  // Measure Acceptance
+	  acceptTraj = acceptReject(DeltaH);
 	}
+	else {
+	  // Warm Up: acceptTraj = true -- always
+	  acceptTraj = true; 
+	}
+
+      }       
+      catch( MGSolverException e ) {
+
+	// Exception Handling if the solver didnt converge
+	// Automatic rejection
+	QDPIO::cout << "WARNING: Caught MG Solver Convergence Exception, during MD or Final Energy Calculation!" << std::endl;
+	QDPIO::cout << "WARNING: Exception was: " << e.whatStr() << std::endl;
+	QDPIO::cout << "WARNING: REJECTING Traj" << std::endl;
+	acceptTraj = false;
+
+	// Stop swatch in case it was running. 
+	swatch.stop();
+	QDPIO::cout << "HMC_TIME: Aborted Traj Time: " << swatch.getTimeInSeconds() << " \n";
       }
 
+      write(xml_out, "AcceptP", acceptTraj);
+      write(xml_log, "AcceptP", acceptTraj);	  
+      QDPIO::cout << "AcceptP = " << acceptTraj << std::endl;
+
+
+      // If reversebility check is due, do it. It doesn't affect the final state 's'
+      if( CheckRevP ) {
+
+	// Copy State
+	Handle< AbsFieldState<P,Q> >  s_rev(s.clone());
+
+	// Try and do reverse trajectory 
+	// If the MG solver fails in this, in some sense I don't care
+	// It doesn't affect acceptance of 's'
+
+	try { 
+	  swatch.reset(); swatch.start();
+	  
+	  QDPIO::cout << "Reversing trajectory for reversability test" <<std::endl;
+	
+	  // Flip Momenta
+	  flipMomenta(*s_rev);
+	
+	  // Go back
+	  MD(*s_rev, MD.getTrajLength());
+
+	  // Flip Momenta back (to original)
+	  flipMomenta(*s_rev);
+
+
+	  Double KE_rev;
+	  Double PE_rev;
+       
+	  H_MC.mesE(*s_rev, KE_rev, PE_rev);
+
+	  Double DeltaDeltaKE = KE_rev - KE_old;
+	  Double DeltaDeltaPE = PE_rev - PE_old;
+	  Double DeltaDeltaH = DeltaDeltaKE + DeltaDeltaPE;
+
+	
+	  Double dq;
+	  Double dp;
+	  reverseCheckMetrics(dq,dp, *s_rev, *s_old);
+
+	  push(xml_log, "ReversibilityMetrics");
+	  write(xml_log, "DeltaDeltaH", fabs(DeltaDeltaH));
+	  write(xml_log, "DeltaDeltaKE", fabs(DeltaDeltaKE));
+	  write(xml_log, "DeltaDeltaPE", fabs(DeltaDeltaPE));
+	  write(xml_log, "DeltaQPerSite", dq);
+	  write(xml_log, "DeltaPPerSite", dp);
+	  pop(xml_log);
+	  
+	  QDPIO::cout << "Reversibility: DeltaDeltaH = " << fabs(DeltaDeltaH) <<std::endl;
+	  QDPIO::cout << "Reversibility: DeltaQ      = " << dq << std::endl;
+	  QDPIO::cout << "Reversibility: DeltaP      = " << dp << std::endl;
+	  swatch.stop();
+	  QDPIO::cout << "HMC_TIME: Reverse Check Time: " << swatch.getTimeInSeconds() << " \n";
+	}
+	catch( MGSolverException e ) { 
+
+	  QDPIO::cout << "WARNING: Caught MG Solver Exception in Reverse Trajectory" << std::endl;
+	  QDPIO::cout << "WARNING: Exception was: " << e.whatStr() << std::endl;
+	  QDPIO::cout << "WARNING: Since traj already finished, I will ignore this" << std::endl;
+
+	  // Stop swatch in case it was running. 
+	  swatch.stop();
+	  QDPIO::cout << "HMC_TIME: Aborted Reverse Traj Time: " << swatch.getTimeInSeconds() << " \n";
+
+	}
+
+	// s_rev goes away here.
+
+      } // if (CheckRevP)
+
+      // Rejection: acceptTraj is false
+      // Either because of exception handling, or 
+      // because of the MC Test
+      if ( ! acceptTraj ) {
+
+	// restore the old state
+	s.getQ() = s_old->getQ();
+	s.getP() = s_old->getP();
+	
+      }
+            
       pop(xml_log); // HMCTrajectory
       pop(xml_out); // HMCTrajectory
     


### PR DESCRIPTION
I have attempted to i) Allow failing solvers (Multigrid for QUDA and MG Proto) to raise exceptions to be caught in the HMC. ii) I have rejiggered the HMC so that any reverseibility test occurs after the acceptance and rejection decision is already made (initial and final energies are evaluated).  This is so that a reversibility test which may evolve a preconditioner back to the start of the original trajectory does not provide a subsequent final energy calculation with a crummy preconditioner. Rather the final energy calc will use the preconditioner, as it is at the proper end of the trajectory before the reverse check. (It may still be bad of course if it is just about  to need refreshment).      

The possibilities for acceptState should be true (always if WarmUp is set or if the acceptReject step accepts), false if acceptReject test rejects or if a MGSolverException is caught. 

I have tested this on Titan and at least when not encountering any exceptions the code appears to repro delta H-s within rounding differences (which can be introduced just by retuning kernels). Still this is sufficiently big a change, that I'd like a code review of the diffs.

Thanks, 
 Balint
