### PR TITLE
Added Projector to UnprecCloverFermAct

### DIFF
--- a/lib/actions/ferm/fermacts/unprec_clover_fermact_w.cc
+++ b/lib/actions/ferm/fermacts/unprec_clover_fermact_w.cc
@@ -7,6 +7,7 @@
 
 #include "actions/ferm/linop/unprec_clover_linop_w.h"
 #include "actions/ferm/fermacts/unprec_clover_fermact_w.h"
+#include "actions/ferm/invert/syssolver_linop_factory.h"
 
 //#include "actions/ferm/fermacts/fermact_factory_w.h"
 #include "actions/ferm/fermstates/ferm_createstate_reader_w.h"
@@ -72,5 +73,20 @@ namespace Chroma
     return new UnprecCloverLinOp(state,param);
   }
 
+
+  //! Return a linear operator solver for this action to solve M*psi=chi 
+  Projector<LatticeFermion>* 
+  UnprecCloverFermAct::projector(Handle< FermState<T,P,Q> > state,
+				     const GroupXML_t& projParam) const
+  {
+    std::istringstream  is(projParam.xml);
+    XMLReader  paramtop(is);
+	
+    return TheLinOpFermProjectorFactory::Instance().createObject(projParam.id,
+								    paramtop,
+								    projParam.path,
+								    state,
+								    linOp(state));
+  }
 }
 

--- a/lib/actions/ferm/fermacts/unprec_clover_fermact_w.h
+++ b/lib/actions/ferm/fermacts/unprec_clover_fermact_w.h
@@ -52,6 +52,10 @@ namespace Chroma
 	return new lgherm<T>(linOp(state));
       }
 
+    //! Return a projector after this action
+    Projector<T>* projector(Handle< FermState<T,P,Q> > state,
+                            const GroupXML_t& projParam) const override;
+
     //! Destructor is automatic
     ~UnprecCloverFermAct() {}
 


### PR DESCRIPTION
Propagating the 'Projector' from EvenOddPrecCloverFermAct to UnprecCloverFermAct (someone should check this -- I just call the Factory ) 

This addition should allow multi-RHS use of QUDA solvers using the UNPRECONDITIONED_CLOVER action in the DISCO_PROBING_DEFLATION measurement once QUDA PR #1504 is merged. Until the merge one should use QUDA branch `feature/full-qdpjit-fields` to use the UNPRECONDITIONED_CLOVER action. 

UNPRECONDITIONED_CLOVER should otherwise be usable in PROPAGATOR etc without this patch once QUDA PR #1504 is merged, or by using QUDA `feature/full-qdpjit-fields` branch until then.

