### PR TITLE
Fixing string reference in enum_quda_io

### DIFF
--- a/lib/actions/ferm/invert/quda_solvers/enum_quda_io.cc
+++ b/lib/actions/ferm/invert/quda_solvers/enum_quda_io.cc
@@ -142,19 +142,19 @@ namespace Chroma {
 			bool success = true;
 
 			// Thick Restarted Lanczos
-			success = theQudaEigTypeMap::Instance().registerPair(string("TR_LANCZOS"), 
+			success = theQudaEigTypeMap::Instance().registerPair(std::string("TR_LANCZOS"), 
 																																	QUDA_EIG_TR_LANCZOS);
 
 		  // Block Thick Restarted Lanczos
-			success &= theQudaEigTypeMap::Instance().registerPair(string("BLK_TR_LANCZOS"), 
+			success &= theQudaEigTypeMap::Instance().registerPair(std::string("BLK_TR_LANCZOS"), 
 																																	QUDA_EIG_BLK_TR_LANCZOS);
 
 			// Implicitly Restarted Arnoldi
-			success &= theQudaEigTypeMap::Instance().registerPair(string("IR_ARNOLDI"), 
+			success &= theQudaEigTypeMap::Instance().registerPair(std::string("IR_ARNOLDI"), 
 																																	QUDA_EIG_IR_ARNOLDI);
 
 			// Block Implicitly Restarted Arnoldi
-			success &= theQudaEigTypeMap::Instance().registerPair(string("BLK_IR_ARNOLDI"), 
+			success &= theQudaEigTypeMap::Instance().registerPair(std::string("BLK_IR_ARNOLDI"), 
 																																	QUDA_EIG_BLK_IR_ARNOLDI);
 			return success;
 		}


### PR DESCRIPTION
Resolves the folowing build failures while building with gcc built openmpi.
```
639.6 /tmp/chroma/lib/actions/ferm/invert/quda_solvers/enum_quda_io.cc:145:57: error: use of undeclared identifier 'string'; did you mean 'std::string'?
639.6   145 |                         success = theQudaEigTypeMap::Instance().registerPair(string("TR_LANCZOS"), 
639.6       |                                                                              ^
639.6 /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stringfwd.h:77:33: note: 'std::string' declared here
639.6    77 |   typedef basic_string<char>    string;   
639.6       |                                 ^
639.6 /tmp/chroma/lib/actions/ferm/invert/quda_solvers/enum_quda_io.cc:149:58: error: use of undeclared identifier 'string'; did you mean 'std::string'?
639.6   149 |                         success &= theQudaEigTypeMap::Instance().registerPair(string("BLK_TR_LANCZOS"), 
639.6       |                                                                               ^
639.6 /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stringfwd.h:77:33: note: 'std::string' declared here
639.6    77 |   typedef basic_string<char>    string;   
639.6       |                                 ^
639.6 /tmp/chroma/lib/actions/ferm/invert/quda_solvers/enum_quda_io.cc:153:58: error: use of undeclared identifier 'string'; did you mean 'std::string'?
639.6   153 |                         success &= theQudaEigTypeMap::Instance().registerPair(string("IR_ARNOLDI"), 
639.6       |                                                                               ^
639.6 /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stringfwd.h:77:33: note: 'std::string' declared here
639.6    77 |   typedef basic_string<char>    string;   
639.6       |                                 ^
639.6 /tmp/chroma/lib/actions/ferm/invert/quda_solvers/enum_quda_io.cc:157:58: error: use of undeclared identifier 'string'; did you mean 'std::string'?
639.6   157 |                         success &= theQudaEigTypeMap::Instance().registerPair(string("BLK_IR_ARNOLDI"), 
639.6       |                                                                               ^
```