### PR TITLE
Add xml_array_utils.h to `ChromaLIB_HEADERS`.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1958,6 +1958,7 @@ if( Chroma_ENABLE_QUDA )
 	actions/ferm/invert/quda_solvers/quda_multigrid_params.h
 	actions/ferm/invert/quda_solvers/qdpjit_memory_wrapper.h
 	actions/ferm/invert/quda_solvers/quda_eig_params.h
+	actions/ferm/invert/quda_solvers/xml_array_utils.h
 	meas/inline/io/inline_erase_quda_multigrid_space.h
 	update/molecdyn/predictor/quda_predictor.h
 )


### PR DESCRIPTION
xml_array_utils.h cannot be found when compiling Chroma extensions as it is not installed in the include directory.